### PR TITLE
Fix 'BUY' & 'SELL' and inputToken & outputToken confusion

### DIFF
--- a/src/parsers/parser-jupiter.ts
+++ b/src/parsers/parser-jupiter.ts
@@ -236,7 +236,7 @@ export class JupiterParser {
     // Determine signer based on DCA program presence
     const signerIndex = this.containsDCAProgram() ? 2 : 0;
     const signer = this.txWithMeta.transaction.message.accountKeys[signerIndex].pubkey.toBase58();
-    const tradeType = Object.values(TOKENS).includes(inMint) ? 'SELL' : 'BUY';
+    const tradeType = Object.values(TOKENS).includes(inMint) ? 'BUY' : 'SELL';
     return {
       type: tradeType,
       inputToken: {

--- a/src/parsers/parser-pumpfun.ts
+++ b/src/parsers/parser-pumpfun.ts
@@ -45,14 +45,14 @@ export class PumpfunParser {
     return {
       type: tradeType,
       inputToken: {
-        mint: isBuy ? event.mint : TOKENS.SOL,
-        amount: isBuy ? event.tokenAmount : event.solAmount,
-        decimals: isBuy ? 6 : 9,
-      },
-      outputToken: {
         mint: isBuy ? TOKENS.SOL : event.mint,
         amount: isBuy ? event.solAmount : event.tokenAmount,
         decimals: isBuy ? 9 : 6,
+      },
+      outputToken: {
+        mint: isBuy ? event.mint : TOKENS.SOL,
+        amount: isBuy ? event.tokenAmount : event.solAmount,
+        decimals: isBuy ? 6 : 9,
       },
       user: event.user,
       programId: DEX_PROGRAMS.PUMP_FUN.id,

--- a/src/transfer-utils.ts
+++ b/src/transfer-utils.ts
@@ -135,7 +135,7 @@ export const processSwapData = (
   }
 
   const { inputToken, outputToken } = calculateTokenAmounts(transfers, uniqueTokens);
-  const tradeType = Object.values(TOKENS).includes(inputToken.mint) ? 'SELL' : 'BUY';
+  const tradeType = Object.values(TOKENS).includes(inputToken.mint) ? 'BUY' : 'SELL';
 
   let signer = txWithMeta.transaction.message.accountKeys[0].pubkey.toBase58();
 


### PR DESCRIPTION
The ‘BUY’ and ‘SELL’ labels seem to be inverted. When a stablecoin is involved as the input token, it should be classified as a ‘BUY’.

The inputToken and outputToken also seem to be inverted in the pumpfun parser. Indeed, the input token is always the WSOL for a "BUY".