### PR TITLE
fix for calculation of intermediate Info

### DIFF
--- a/src/parsers/parser-jupiter.ts
+++ b/src/parsers/parser-jupiter.ts
@@ -215,13 +215,16 @@ export class JupiterParser {
       const inputMint = event.inputMint.toBase58();
       const outputMint = event.outputMint.toBase58();
 
+      const inputAmount = BigInt(event.inputAmount.toString());
+      const outputAmount = BigInt(event.outputAmount.toString());
+
       intermediateInfo.tokenIn.set(
         inputMint,
-        (intermediateInfo.tokenIn.get(inputMint) || BigInt(0)) + event.inputAmount
+        (intermediateInfo.tokenIn.get(inputMint) || BigInt(0)) + inputAmount
       );
       intermediateInfo.tokenOut.set(
         outputMint,
-        (intermediateInfo.tokenOut.get(outputMint) || BigInt(0)) + event.outputAmount
+        (intermediateInfo.tokenOut.get(outputMint) || BigInt(0)) + outputAmount
       );
 
       intermediateInfo.decimals.set(inputMint, event.inputMintDecimals);


### PR DESCRIPTION
Examle of transactions which calculated incorectly 

https://solscan.io/tx/5Db4JYu5oCLqhXvJ9VWXk3ubZ7H1Naah3VvPSA3oiMq9DLQNHdBQEVCmBD8toC9x6Pa6wukhg6x43e136NQKyCiz

Right now its calculated like 
`[
      {
        type: 'SELL',
        inputToken: {
          mint: '4TBi66vi32S7J8X1A6eWfaLHYmUXu7CStcEmsJQdpump',
          amount: 3500000000015000,
          decimals: 6
        },
        outputToken: {
          mint: 'So11111111111111111111111111111111111111112',
          amount: 78877003393.42476,
          decimals: 9
        },
        user: 'DNt9Bhab1dioyw48eNCb6VWRjHzQbXjm8U4fHYAic4tc',
        programId: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4',
        amm: 'MeteoraDLMM',
        route: 'Jupiter',
        slot: 329578761,
        timestamp: 1743103778,
        signature: '5Db4JYu5oCLqhXvJ9VWXk3ubZ7H1Naah3VvPSA3oiMq9DLQNHdBQEVCmBD8toC9x6Pa6wukhg6x43e136NQKyCiz',
        idx: '3-1'
      }
    ]`
    
    
because of conflict bigint and bn.js amount calculated as string 
    `
    amount: 3500000000015000
    `
after fix, its calculated like this

`[
      {
        type: 'SELL',
        inputToken: {
          mint: '4TBi66vi32S7J8X1A6eWfaLHYmUXu7CStcEmsJQdpump',
          amount: 50000,
          decimals: 6
        },
        outputToken: {
          mint: 'So11111111111111111111111111111111111111112',
          amount: 11.312448397,
          decimals: 9
        },
        user: 'DNt9Bhab1dioyw48eNCb6VWRjHzQbXjm8U4fHYAic4tc',
        programId: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4',
        amm: 'MeteoraDLMM',
        route: 'Jupiter',
        slot: 329578761,
        timestamp: 1743103778,
        signature: '5Db4JYu5oCLqhXvJ9VWXk3ubZ7H1Naah3VvPSA3oiMq9DLQNHdBQEVCmBD8toC9x6Pa6wukhg6x43e136NQKyCiz',
        idx: '3-1'
      }
    ]`
    